### PR TITLE
fix: force poetry-core <2.0 for buildC (#1689)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -132,7 +132,7 @@ azure-identity = "^1.14.1"
 azure-storage-file-datalake = "^12.14.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core==1.9.1"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
Fix frontend builds for repo-based installs.

## Review instructions
1. `poetry add 'git+https://github.com/SynergyOS-ai/chainlit.git@fix_frontend_build#subdirectory=backend/'`
2. `./scripts/run.sh`
3. All is well: PP is working! (or not...)

It's possible there's caching errors, in which case you might have to do something like `rm -rf /Users/drbob/Library/Caches/pypoetry/virtualenvs/purposeai-3Vh0CB4X-py3.11/src/chainlit` (but for your own virtualenv)